### PR TITLE
Load google fonts over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Emoji Ipsum</title>
-    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,500' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,500' rel='stylesheet' type='text/css'>
     <link href='css/main.css' rel='stylesheet' type='text/css'>
   </head>
   <body>


### PR DESCRIPTION
Now that the site's using https (#6) these need to be loaded over https too.